### PR TITLE
chore(anyalysis_options): throw error when using relative imports

### DIFF
--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -7,6 +7,7 @@ analyzer:
     unused_local_variable: error
     dead_code: error
     missing_required_param: error
+    always_use_package_imports: error
   exclude:
     - lib/**.freezed.dart
     - lib/**.g.dart


### PR DESCRIPTION

Update lint rules to return an error when using relative imports over package imports